### PR TITLE
Fix for XSS vulnerability in diff view

### DIFF
--- a/lib/irwi/helpers/wiki_pages_helper.rb
+++ b/lib/irwi/helpers/wiki_pages_helper.rb
@@ -39,7 +39,7 @@ module Irwi::Helpers::WikiPagesHelper
   end
   
   def wiki_diff( old_text, new_text )
-    Irwi.config.comparator.render_changes( old_text, new_text )
+    Irwi.config.comparator.render_changes(h(old_text), h(new_text))
   end
   
   def wiki_user( user )

--- a/spec/helpers/wiki_pages_helper_spec.rb
+++ b/spec/helpers/wiki_pages_helper_spec.rb
@@ -148,6 +148,11 @@ describe Irwi::Helpers::WikiPagesHelper do
       @m.wiki_link( 'Page title' ).should == 'url'
     end
     
+    specify "not be vulnerable to XSS when showing a diff" do
+      xss = '<script>alert("exploit")</script>'  
+      @m.wiki_diff('foo bar', "foo #{xss} bar").should_not include(xss)
+    end
+    
   end
   
 end


### PR DESCRIPTION
Hi,

This patch addresses a possible XSS exploit.  
When viewing a Wiki page, HTML is properly escaped but it was not when showing the diff.

Regards,
