### PR TITLE
add page to compare path in form

### DIFF
--- a/app/views/base_wiki_pages/_wiki_page_history.html.erb
+++ b/app/views/base_wiki_pages/_wiki_page_history.html.erb
@@ -1,5 +1,5 @@
 <% if with_form %>
-  <form action="<%=wiki_page_compare_path%>" method="get">
+  <form action="<%=wiki_page_compare_path local_assigns[:page]%>" method="get">
 <% end %>
 
 <table class="wiki_history">


### PR DESCRIPTION
 it was always wiki/compare instead of wiki/compare/page_path, so root page will be compared instead of current page