### PR TITLE
i18n.translate wrong number of params fix

### DIFF
--- a/lib/irwi/helpers/wiki_pages_helper.rb
+++ b/lib/irwi/helpers/wiki_pages_helper.rb
@@ -97,7 +97,7 @@ module Irwi::Helpers::WikiPagesHelper
     config = args.extract_options!
     config[:default] = msg if config[:default].blank?
     config[:scope] = 'wiki'
-    I18n.t(msg, config)
+    I18n.t(msg, **config)
   end
 
   def wiki_page_style


### PR DESCRIPTION
Support splatted params in Ruby 3